### PR TITLE
Fixed timeout on slow connection

### DIFF
--- a/ui/ui-app/src/main/resources/static/js/main.js
+++ b/ui/ui-app/src/main/resources/static/js/main.js
@@ -1,4 +1,5 @@
 require.config({
+    waitSeconds: 0,
     baseUrl: "js",
     paths: {
         "angular":"../bower_components/angular/angular",


### PR DESCRIPTION
Hello,

on a slow connection, the Kulo UI times out on require.js resource loading. This small change disables the timeout.