### PR TITLE
Added TO_DATE as available partition function for Kylo feeds

### DIFF
--- a/services/feed-manager-service/feed-manager-controller/src/main/java/com/thinkbiganalytics/feedmgr/rest/controller/UtilityRestController.java
+++ b/services/feed-manager-service/feed-manager-controller/src/main/java/com/thinkbiganalytics/feedmgr/rest/controller/UtilityRestController.java
@@ -204,7 +204,7 @@ public class UtilityRestController {
     )
     @Nonnull
     public Response partitionFunctions() {
-        final Stream<String> kyloFunctions = Stream.of("val", "year", "month", "day", "hour", "minute");
+        final Stream<String> kyloFunctions = Stream.of("val", "to_date", "year", "month", "day", "hour", "minute");
         final Stream<String> userFunctions = Arrays.stream(env.getProperty("kylo.metadata.udfs", "").split(",")).map(String::trim).filter(StringUtils::isNotEmpty);
         return Response.ok(Stream.concat(kyloFunctions, userFunctions).collect(Collectors.toSet())).build();
     }

--- a/services/feed-manager-service/feed-manager-rest-model/src/main/java/com/thinkbiganalytics/feedmgr/rest/model/schema/PartitionField.java
+++ b/services/feed-manager-service/feed-manager-rest-model/src/main/java/com/thinkbiganalytics/feedmgr/rest/model/schema/PartitionField.java
@@ -99,7 +99,7 @@ public class PartitionField {
     }
 
     public static enum PARTITON_FORMULA {
-        YEAR("int"), MONTH("int"), DAY("int"), HOUR("int"), MIN("int"), SEC("int"), VAL("string", true);
+        TO_DATE("date"), YEAR("int"), MONTH("int"), DAY("int"), HOUR("int"), MIN("int"), SEC("int"), VAL("string", true);
 
 
         private boolean useColumnDataType;

--- a/ui/ui-app/src/main/resources/static/js/feed-mgr/feeds/define-feed/feed-details/DefineFeedTableDirective.js
+++ b/ui/ui-app/src/main/resources/static/js/feed-mgr/feeds/define-feed/feed-details/DefineFeedTableDirective.js
@@ -712,7 +712,7 @@ define(['angular','feed-mgr/feeds/define-feed/module-name'], function (angular,m
 
             // Filter formulas based on column type
             if (columnDef.derivedDataType !== "date" && columnDef.derivedDataType !== "timestamp") {
-                return _.without(formulas, "year", "month", "day", "hour", "minute");
+                return _.without(formulas, "to_date", "year", "month", "day", "hour", "minute");
             } else {
                return formulas;
             }

--- a/ui/ui-feed-manager/src/main/resources/static-feed-mgr/js/define-feed/feed-details/DefineFeedTableDirective.js
+++ b/ui/ui-feed-manager/src/main/resources/static-feed-mgr/js/define-feed/feed-details/DefineFeedTableDirective.js
@@ -705,7 +705,7 @@
 
             // Filter formulas based on column type
             if (columnDef.derivedDataType !== "date" && columnDef.derivedDataType !== "timestamp") {
-                return _.without(formulas, "to_date" "year", "month", "day", "hour", "minute");
+                return _.without(formulas, "to_date", "year", "month", "day", "hour", "minute");
             } else {
                return formulas;
             }

--- a/ui/ui-feed-manager/src/main/resources/static-feed-mgr/js/define-feed/feed-details/DefineFeedTableDirective.js
+++ b/ui/ui-feed-manager/src/main/resources/static-feed-mgr/js/define-feed/feed-details/DefineFeedTableDirective.js
@@ -705,7 +705,7 @@
 
             // Filter formulas based on column type
             if (columnDef.derivedDataType !== "date" && columnDef.derivedDataType !== "timestamp") {
-                return _.without(formulas, "year", "month", "day", "hour", "minute");
+                return _.without(formulas, "to_date" "year", "month", "day", "hour", "minute");
             } else {
                return formulas;
             }


### PR DESCRIPTION
Added the to_date function so that Timestamps can be partitioned by a date function, instead of year, month, day as recommended best practice by Hortonworks.

https://community.hortonworks.com/questions/29031/best-pratices-for-hive-partitioning-especially-by.html