### PR TITLE
KYLO-401 Fixed authorization.sentry.properties reference in Sentry

### DIFF
--- a/plugins/hadoop-authorization-sentry-default/hadoop-authorization-sentry/src/main/java/com/thinkbiganalytics/datalake/authorization/config/SentryConfiguration.java
+++ b/plugins/hadoop-authorization-sentry-default/hadoop-authorization-sentry/src/main/java/com/thinkbiganalytics/datalake/authorization/config/SentryConfiguration.java
@@ -37,7 +37,7 @@ import javax.sql.DataSource;
 /**
  */
 @Configuration
-@PropertySource("classpath:/conf/authorization.sentry.properties")
+@PropertySource("classpath:authorization.sentry.properties")
 public class SentryConfiguration {
 
     private static Logger log = LoggerFactory.getLogger(SentryConfiguration.class);


### PR DESCRIPTION
Changed hard coded reference of sentry property file. Initially it was referring authorization property file from jar instead of Kylo-service/conf location. Every change to property file was ended up being new sentry jar. 