### PR TITLE
sonarqube integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,15 @@ addons:
   apt:
     packages:
     - rpm
+  sonarqube:
+    organization: ${SONAR_ORGANIZATION}
+    token:
+      secure: ${SONAR_TOKEN}
+    github_token:
+      secure: ${GITHUB_TOKEN}
 
 install: "[ -e $HOME/.m2/repository ] || curl https://s3-us-west-2.amazonaws.com/thinkbig.kylo/m2.tgz | tar xzC $HOME"
-script: mvn clean install -B -V
+script: mvn clean install sonar:sonar -B -V
 
 # Cache .m2 directory for next run
 before_cache: "rm -rf $HOME/.m2/repository/com/thinkbiganalytics"


### PR DESCRIPTION
This is an attempt to enable the use of SonarQube.com for quality analysis.
To set the values for the needed environment variables in Travis follow this [documentation](https://docs.travis-ci.com/user/sonarqube/#SonarQube-Scanner-for-Maven):
- `SONAR_ORGANIZATION`: name of the organisation in Sonarqube
- `SONAR_TOKEN`: the token generated in Sonarqube
- `GITHUB_TOKEN`: (to be able to run sonar on pull requests) github personal access token [doc](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)