### PR TITLE
Removed hard coded name for profiler job

### DIFF
--- a/integrations/spark/spark-job-profiler/spark-job-profiler-app/src/main/java/com/thinkbiganalytics/spark/dataprofiler/core/Profiler.java
+++ b/integrations/spark/spark-job-profiler/spark-job-profiler-app/src/main/java/com/thinkbiganalytics/spark/dataprofiler/core/Profiler.java
@@ -111,7 +111,7 @@ public class Profiler {
         }
 
         /* Initialize and configure Spark */
-        conf = new SparkConf().setAppName(ProfilerConfiguration.APP_NAME);
+        conf = new SparkConf();
 
         if (ProfilerConfiguration.SERIALIZER.equals("kryo")) {
             conf = configureEfficientSerialization(conf);


### PR DESCRIPTION
Having hard coded value for application name prevents to use different name when running this job from NiFi, e.g. by using ExecuteSparkJob processor