### PR TITLE
Fix maven parser warnings

### DIFF
--- a/install/install-debian/pom.xml
+++ b/install/install-debian/pom.xml
@@ -34,8 +34,8 @@
               <goal>jdeb</goal>
             </goals>
             <configuration>
-              <deb>${build.directory}/deb/kylo-${version}.deb</deb>
-              <controlDir>${build.directory}/kylo-install-debian-${version}-dependencies/deb-control</controlDir>
+              <deb>${project.build.directory}/deb/kylo-${project.version}.deb</deb>
+              <controlDir>${project.build.directory}/kylo-install-debian-${project.version}-dependencies/deb-control</controlDir>
               <dataSet>
                 <data>
                   <src>../install-tar/target/kylo-${project.version}-dependencies.tar.gz</src>

--- a/plugins/search-elasticsearch/pom.xml
+++ b/plugins/search-elasticsearch/pom.xml
@@ -16,6 +16,17 @@
   </properties>
   <artifactId>kylo-search-elasticsearch</artifactId>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.modeshape.bom</groupId>
+        <artifactId>modeshape-bom-embedded</artifactId>
+        <version>${modeshape.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.thinkbiganalytics.datalake</groupId>
@@ -51,14 +62,6 @@
       <groupId>org.modeshape</groupId>
       <artifactId>modeshape-elasticsearch-index-provider</artifactId>
       <version>${elasticsearchindexprovider.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.modeshape.bom</groupId>
-      <artifactId>modeshape-bom-embedded</artifactId>
-      <version>${modeshape.version}</version>
-      <type>pom</type>
-      <scope>import</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -952,6 +952,11 @@
           <artifactId>maven-antrun-plugin</artifactId>
           <version>1.7</version>
         </plugin>
+        <plugin>
+          <groupId>com.github.searls</groupId>
+          <artifactId>jasmine-maven-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/services/feed-manager-service/feed-manager-controller/pom.xml
+++ b/services/feed-manager-service/feed-manager-controller/pom.xml
@@ -108,13 +108,6 @@
 
     <dependency>
       <groupId>com.thinkbiganalytics.datalake</groupId>
-      <artifactId>kylo-operational-metadata-rest-model</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-
-    <dependency>
-      <groupId>com.thinkbiganalytics.datalake</groupId>
       <artifactId>kylo-feed-manager-core</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -404,11 +397,6 @@
       <artifactId>kylo-commons-test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
This small PR fixes warnings that appear at the beginning of the build log and are reported by Maven during project parsing.

Some of them might be dangerous in the long run - here is the summary:

- import of `modeshape-bom-embedded` was not effective (used in deps instead of DM)
- missing explicit plugin version - this can be automatically catched by configuring [maven-enforcer-plugin](http://maven.apache.org/enforcer/enforcer-rules/requirePluginVersions.html)
- in POMs, all references to Maven project properties should be prefixed with `project.` (cosmetic)
- duplicate references (mostly cosmetic)

These changes are provided as separate commits.
