### PR TITLE
Configure build JVM params in `.mvn/jvm.config`

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xms2g -Xmx4g

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ sudo: required
 # Set build lifecycle options
 env:
   global:
-  - MAVEN_OPTS="-Xms2g -Xmx4g"
   - MAVEN_SKIP_RC=true
 
 addons:


### PR DESCRIPTION
With this, yet another project-wide build configuration will be part of the project code.

This patch ensures that all developers build this project with the same JVM params, without having to care whenever they switch projects.

As a result, it is no longer necessary to keep this setting in the `.travis.yml` script so I removed it.

The `.mvn` feature is available in maven since version 3.3.1 - see https://maven.apache.org/docs/3.3.1/release-notes.html for more details.