### PR TITLE
KYLO-996 - Hive Kerberos comparison fails for upper case values

### DIFF
--- a/services/service-app/src/main/java/com/thinkbiganalytics/kerberos/KerberosConfiguration.java
+++ b/services/service-app/src/main/java/com/thinkbiganalytics/kerberos/KerberosConfiguration.java
@@ -46,7 +46,7 @@ public class KerberosConfiguration {
         String keytabLocation = env.getProperty("kerberos.hive.keytabLocation");
 
         KerberosTicketConfiguration config = new KerberosTicketConfiguration();
-        config.setKerberosEnabled("true".equals(kerberosEnabled) ? true : false);
+        config.setKerberosEnabled("true".equalsIgnoreCase(kerberosEnabled) ? true : false);
         config.setHadoopConfigurationResources(hadoopConfigurationResources);
         config.setKerberosPrincipal(kerberosPrincipal);
         config.setKeytabLocation(keytabLocation);


### PR DESCRIPTION
Changing case comparison for Hive Kerberos enable property.