### PR TITLE
Remove localhost broker from activemq.properties

### DIFF
--- a/plugins/jms-service-activemq/src/main/resources/activemq.properties
+++ b/plugins/jms-service-activemq/src/main/resources/activemq.properties
@@ -17,7 +17,7 @@
 # limitations under the License.
 # #L%
 ###
-jms.activemq.broker.url=tcp://localhost:61616
+#jms.activemq.broker.url=tcp://localhost:61616
 #jms.activemq.broker.username=admin
 #jms.activemq.broker.password=admin
 ##Redeliver policy for the Listeners when they fail (http://activemq.apache.org/redelivery-policy.html)


### PR DESCRIPTION
This fixes a bug where nifi can't be configured to use the correct activemq broker url since this file overwrites the values in ext-config. 

From the google group:

>In: https://github.com/Teradata/kylo/blob/master/plugins/jms-service-activemq/src/main/java/com/thinkbiganalytics/jms/activemq/ActiveMqConfig.java
>we see that "file:${kylo.nifi.configPath}/config.properties" is defined before "classpath:activemq.properties". activemq.properties is on the classpath and contains the setting for localhost for activemq which overwrites the value we specify in ext-config. 
>https://github.com/Teradata/kylo/blob/master/plugins/jms-service-activemq/src/main/resources/activemq.properties