### PR TITLE
KYLO-1179 not able to override properties defined in activemq.properties

### DIFF
--- a/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/main/resources/ext-config/config.properties
+++ b/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/main/resources/ext-config/config.properties
@@ -1,0 +1,23 @@
+###
+# #%L
+# thinkbig-nifi-provenance-repo
+# %%
+# Copyright (C) 2017 ThinkBig Analytics
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+
+spring.profiles.active=jms-activemq
+
+###
+jms.activemq.broker.url=tcp://external:61616

--- a/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/test/java/com/thinkbiganalytics/nifi/provenance/TestConfig.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/test/java/com/thinkbiganalytics/nifi/provenance/TestConfig.java
@@ -32,15 +32,15 @@ import org.springframework.core.io.ClassPathResource;
  */
 // Ignore due to dependency on MySQL
 @Ignore
-@Configuration
-@ComponentScan(basePackages = {"com.thinkbiganalytics"})
-@PropertySource("classpath:config.properties")
+//@Configuration
+//@ComponentScan(basePackages = {"com.thinkbiganalytics"})
+//@PropertySource("classpath:config.properties")
 public class TestConfig {
 
-    @Autowired
+    //@Autowired
     private Environment env;
 
-    @Bean
+    //@Bean
     public PropertyPlaceholderConfigurer propConfig() {
         PropertyPlaceholderConfigurer placeholderConfigurer = new PropertyPlaceholderConfigurer();
         placeholderConfigurer.setLocation(new ClassPathResource("config.properties"));

--- a/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/test/java/com/thinkbiganalytics/nifi/provenance/repo/KyloProvenanceEventRepositoryUtilTest.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/test/java/com/thinkbiganalytics/nifi/provenance/repo/KyloProvenanceEventRepositoryUtilTest.java
@@ -20,12 +20,19 @@ package com.thinkbiganalytics.nifi.provenance.repo;
  * #L%
  */
 
+import com.thinkbiganalytics.nifi.provenance.util.SpringApplicationContext;
+
+import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Created by ru186002 on 21/07/2017.
  */
 public class KyloProvenanceEventRepositoryUtilTest {
+
+    private static final Logger log = LoggerFactory.getLogger(KyloProvenanceEventRepositoryUtilTest.class);
 
     @Test
     public void testLoadDynamicSpringProfile() {
@@ -33,4 +40,17 @@ public class KyloProvenanceEventRepositoryUtilTest {
 //        util.loadSpring();
     }
 
+
+    @Test
+    public void testLoadNifiExternalConfiguration() {
+        String configFilePath = getClass().getClassLoader().getResource("ext-config/config.properties").getPath();
+        System.setProperty("kylo.nifi.configPath", configFilePath.substring(0, configFilePath.indexOf("config.properties") - 1));
+
+        KyloProvenanceEventRepositoryUtil util = new KyloProvenanceEventRepositoryUtil();
+        util.loadSpring();
+
+        String jmsActivemqBrokerUrl = SpringApplicationContext.getInstance().getApplicationContext().getEnvironment().getProperty("jms.activemq.broker.url");
+
+        Assert.assertEquals("tcp://external:61616", jmsActivemqBrokerUrl);
+    }
 }

--- a/plugins/jms-service-activemq/src/main/java/com/thinkbiganalytics/jms/activemq/ActiveMqConfig.java
+++ b/plugins/jms-service-activemq/src/main/java/com/thinkbiganalytics/jms/activemq/ActiveMqConfig.java
@@ -43,10 +43,7 @@ import javax.jms.ConnectionFactory;
  */
 @Profile("jms-activemq")
 @Configuration
-@PropertySources({
-                     @PropertySource(value = "classpath:activemq.properties", ignoreResourceNotFound = true),
-                     @PropertySource(value = "file:${kylo.nifi.configPath}/config.properties", ignoreResourceNotFound = true)
-                 })
+@PropertySource(value = "file:${kylo.nifi.configPath}/config.properties", ignoreResourceNotFound = true)
 public class ActiveMqConfig {
 
     private static final Logger log = LoggerFactory.getLogger(ActiveMqConfig.class);
@@ -66,7 +63,7 @@ public class ActiveMqConfig {
         factory.setRedeliveryPolicy(new RedeliveryPolicy());
         factory.getRedeliveryPolicy().setMaximumRedeliveries(env.getProperty("jms.maximumRedeliveries", Integer.class, 100));
         factory.getRedeliveryPolicy().setRedeliveryDelay(env.getProperty("jms.redeliveryDelay", Long.class, 1000L));
-        factory.getRedeliveryPolicy().setInitialRedeliveryDelay(env.getProperty("jms.initialRedeliveryDelay",Long.class,1000L));
+        factory.getRedeliveryPolicy().setInitialRedeliveryDelay(env.getProperty("jms.initialRedeliveryDelay", Long.class, 1000L));
         factory.getRedeliveryPolicy().setMaximumRedeliveryDelay(env.getProperty("jms.maximumRedeliveryDelay", Long.class, 600000L));  // try for 10 min
         factory.getRedeliveryPolicy().setBackOffMultiplier(env.getProperty("jms.backOffMultiplier", Double.class, 5d));
         factory.getRedeliveryPolicy().setUseExponentialBackOff(env.getProperty("jms.useExponentialBackOff", Boolean.class, false));


### PR DESCRIPTION
The properties defined in activemq.properties are not overridden by the one defined in the external configuration file. As in activemq.properties is defined the property jms.activemq.broker.url=tcp://localhost:61616 the result is that in it is not possible to connect to a ActiveMQ that is running on another host/port. 

The workaround is to specify the property as commandline system param in conf/bootstrap.conf:
java.arg.XX=-Djms.activemq.broker.url=tcp://my-activemq-host:61616 

This happens in the spring context created by KyloProvenanceEventRepositoryUtil.loadSpring().

The solution is to completely remove the activemq.properties file.