### PR TITLE
KYLO-994 Fix sla-email for gmail and outlook accounts. Fix property issues with sla-email. Minor improvements

### DIFF
--- a/plugins/sla-email/README.md
+++ b/plugins/sla-email/README.md
@@ -1,31 +1,45 @@
-Service Level Agreement Email Action
-====
-This module allows users to configure Service Level Agreements (SLA) to send emails when the SLA is violated.
-To use this you need to include this jar in the /plugin directory (/opt/kylo/kylo-services/plugin) and configure the properties (sla.email.properties) to connect to your mail server.
-As part of the default rpm build this module and the respective properties file is included with the build.
+# Service Level Agreement Email Action
 
-Email Properties
-===
-The system will look for properties starting with the prefix sla.mail
-Below is an example properties file:
+This module allows users to configure Service Level Agreements (SLA) to send emails when the SLA is violated.
+
+## Setup
+
+Add plugin jar `kylo/plugins/sla-email` from Kylo repository to
+```
+$KYLO-HOME/kylo-services/plugin
+```
+
+Configure file
+```
+$KYLO-HOME/kylo-services/conf/sla.email.properties
+```
+
+## Email Properties
+
+The system will look for properties starting with the prefix `sla.mail`
+
+Below is an example properties file (for Gmail):
 
 ```
-## if sla-email jar is a configured plugin configure the Email connection
-##uncommenet the settings below for Gmail to work
 sla.mail.protocol=smtp
-sla.mail.host=smtp.google.com
+sla.mail.host=smtp.gmail.com
 sla.mail.port=587
 sla.mail.smtpAuth=true
 sla.mail.starttls=true
-####Note gmail will not respect the from address due to their security restraints, but other systems will
+
+# Note Gmail will not respect the from address due to their security restraints, but other systems will
+# Note Outlook will not send an email if the from address is not a valid outlook email (can be the username email)
+# Default sla.mail.from=sla.mail.username
 sla.mail.from=sla-violation@thinkbiganalytics.com
+
 sla.mail.username=<USERNAME>
 sla.mail.password=<PASSWORD>
-####additional options (not needed for gmail, but for other servers)
-##sla.mail.sslEnable=true
-##sla.mail.smptAuthNtmlDomain=<SOME_DOMAIN>
+
+# Additional options (not needed for gmail, but for other servers)
+# sla.mail.sslEnable=true
+# sla.mail.smptAuthNtmlDomain=<SOME_DOMAIN>
 ```
 
-Other
-====
-For more information on how this plugin works please refer to the sla-core/README.md on how you can extend the SLA framework and create your own Actions when an SLA is violated.
+## Other
+
+For more information on how this plugin works please refer to the [core/sla/README.md](../../core/sla/README.md) on how you can extend the SLA framework and create your own Actions when an SLA is violated.

--- a/plugins/sla-email/src/main/java/com/thinkbiganalytics/metadata/sla/EmailConfiguration.java
+++ b/plugins/sla-email/src/main/java/com/thinkbiganalytics/metadata/sla/EmailConfiguration.java
@@ -34,14 +34,82 @@ public class EmailConfiguration {
     private String protocol;
     private String host;
     private int port;
-    private boolean smtpAuth;
-    private boolean starttls;
+    private String smtpAuth;
+    private String starttls;
+    private String starttlsRequired;
     private String from;
     private String username;
     private String password;
     private String smptAuthNtmlDomain;
-    private boolean sslEnable;
-    private boolean debug;
+    private String sslEnable;
+    private String debug;
+    private String smtpConnectionTimeout;
+    private String smtpTimeout;
+    private String smtpWriteTimeout;
+
+    public String getSmtpAuth() {
+        return smtpAuth;
+    }
+
+    public void setSmtpAuth(String smtpAuth) {
+        this.smtpAuth = smtpAuth;
+    }
+
+    public String getStarttls() {
+        return starttls;
+    }
+
+    public void setStarttls(String starttls) {
+        this.starttls = starttls;
+    }
+
+    public String getStarttlsRequired() {
+        return starttlsRequired;
+    }
+
+    public void setStarttlsRequired(String starttlsRequired) {
+        this.starttlsRequired = starttlsRequired;
+    }
+
+    public String getSslEnable() {
+        return sslEnable;
+    }
+
+    public void setSslEnable(String sslEnable) {
+        this.sslEnable = sslEnable;
+    }
+
+    public String getDebug() {
+        return debug;
+    }
+
+    public void setDebug(String debug) {
+        this.debug = debug;
+    }
+
+    public String getSmtpConnectionTimeout() {
+        return smtpConnectionTimeout;
+    }
+
+    public void setSmtpConnectionTimeout(String smtpConnectionTimeout) {
+        this.smtpConnectionTimeout = smtpConnectionTimeout;
+    }
+
+    public String getSmtpTimeout() {
+        return smtpTimeout;
+    }
+
+    public void setSmtpTimeout(String smtpTimeout) {
+        this.smtpTimeout = smtpTimeout;
+    }
+
+    public String getSmtpWriteTimeout() {
+        return smtpWriteTimeout;
+    }
+
+    public void setSmtpWriteTimeout(String smtpWriteTimeout) {
+        this.smtpWriteTimeout = smtpWriteTimeout;
+    }
 
     public String getProtocol() {
         return protocol;
@@ -65,22 +133,6 @@ public class EmailConfiguration {
 
     public void setPort(int port) {
         this.port = port;
-    }
-
-    public boolean isSmtpAuth() {
-        return smtpAuth;
-    }
-
-    public void setSmtpAuth(boolean smtpAuth) {
-        this.smtpAuth = smtpAuth;
-    }
-
-    public boolean isStarttls() {
-        return starttls;
-    }
-
-    public void setStarttls(boolean starttls) {
-        this.starttls = starttls;
     }
 
     public String getFrom() {
@@ -115,23 +167,8 @@ public class EmailConfiguration {
         this.smptAuthNtmlDomain = smptAuthNtmlDomain;
     }
 
-    public boolean isSslEnable() {
-        return sslEnable;
-    }
-
-    public void setSslEnable(boolean sslEnable) {
-        this.sslEnable = sslEnable;
-    }
-
     public boolean isConfigured() {
-        return StringUtils.isNotBlank(getHost()) && StringUtils.isNotBlank(getProtocol());
+        return StringUtils.isNotBlank(getHost()) && (getPort() > 0);
     }
 
-    public boolean isDebug() {
-        return debug;
-    }
-
-    public void setDebug(boolean debug) {
-        this.debug = debug;
-    }
 }

--- a/plugins/sla-email/src/main/java/com/thinkbiganalytics/metadata/sla/EmailServiceLevelAgreementAction.java
+++ b/plugins/sla-email/src/main/java/com/thinkbiganalytics/metadata/sla/EmailServiceLevelAgreementAction.java
@@ -50,18 +50,13 @@ public class EmailServiceLevelAgreementAction implements ServiceLevelAgreementAc
         String desc = ServiceLevelAssessmentAlertUtil.getDescription(assessment);
         String slaName = assessment.getAgreement().getName();
         String emails = actionConfiguration.getEmailAddresses();
-        sendToAddresses(desc, slaName, emails);
+        sendToAddresses(emails, slaName, desc);
         return true;
     }
 
-    void sendToAddresses(String desc, String slaName, String emails) {
-        String[] addresses = emails.split(",");
-        Arrays.stream(addresses).forEach(address -> sendToAddress(desc, slaName, address.trim()));
-    }
-
-    private void sendToAddress(String desc, String slaName, String address) {
-        log.info("Responding to SLA violation.  About to send an email for SLA {} ", slaName);
-        emailService.sendMail(address, "SLA Violated: " + slaName, desc);
+    public void sendToAddresses(String addresses, String slaName, String desc) {
+        log.info("Responding to SLA violation.  About to send an email for SLA: {} ", slaName);
+        emailService.sendMail(addresses, "SLA Violated: " + slaName, desc);
     }
 
     /**

--- a/plugins/sla-email/src/main/java/com/thinkbiganalytics/metadata/sla/config/EmailServiceLevelAgreementSpringConfiguration.java
+++ b/plugins/sla-email/src/main/java/com/thinkbiganalytics/metadata/sla/config/EmailServiceLevelAgreementSpringConfiguration.java
@@ -59,26 +59,35 @@ public class EmailServiceLevelAgreementSpringConfiguration {
     @Bean(name = "slaEmailSender")
     public JavaMailSender javaMailSender(@Qualifier("slaEmailConfiguration") EmailConfiguration emailConfiguration) {
         JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-        Properties mailProperties = new Properties();
-        mailProperties.put("mail.smtp.auth", emailConfiguration.isSmtpAuth());
-        mailProperties.put("mail.smtp.starttls.enable", emailConfiguration.isStarttls());
+
+        Properties mailProperties = mailSender.getJavaMailProperties();
+        mailProperties.put("mail.smtp.auth", StringUtils.defaultIfBlank(emailConfiguration.getSmtpAuth(),"true"));
+        mailProperties.put("mail.smtp.starttls.enable", StringUtils.defaultIfBlank(emailConfiguration.getStarttls(),"true"));
+
+        if (StringUtils.isNotBlank(emailConfiguration.getStarttlsRequired())) {
+            mailProperties.put("mail.smtp.starttls.required", emailConfiguration.getStarttlsRequired());
+        }
         if (StringUtils.isNotBlank(emailConfiguration.getSmptAuthNtmlDomain())) {
             mailProperties.put("mail.smtp.auth.ntlm.domain", emailConfiguration.getSmptAuthNtmlDomain());
         }
-        mailProperties.put("mail.smtp.connectiontimeout ", "5000");
-        mailProperties.put("mail.smtp.timeout", "5000");
-        mailProperties.put("mail.smtp.writetimeout", "5000");
-        if (emailConfiguration.isSslEnable()) {
-            mailProperties.put("mail.smtp.ssl.enable", "true");
-        }
-        mailProperties.put("mail.debug", emailConfiguration.isDebug());
 
-        mailSender.setJavaMailProperties(mailProperties);
+        mailProperties.put("mail.smtp.connectiontimeout", StringUtils.defaultIfBlank(emailConfiguration.getSmtpConnectionTimeout(),"5000"));
+        mailProperties.put("mail.smtp.timeout", StringUtils.defaultIfBlank(emailConfiguration.getSmtpTimeout(),"5000"));
+        mailProperties.put("mail.smtp.writetimeout", StringUtils.defaultIfBlank(emailConfiguration.getSmtpWriteTimeout(),"5000"));
+
+        if (StringUtils.isNotBlank(emailConfiguration.getSslEnable())) {
+            mailProperties.put("mail.smtp.ssl.enable", emailConfiguration.getSslEnable());
+        }
+        if (StringUtils.isNotBlank(emailConfiguration.getDebug())) {
+            mailProperties.put("mail.debug", emailConfiguration.getDebug());
+        }
+
         mailSender.setHost(emailConfiguration.getHost());
         mailSender.setPort(emailConfiguration.getPort());
         mailSender.setProtocol(emailConfiguration.getProtocol());
         mailSender.setUsername(emailConfiguration.getUsername());
         mailSender.setPassword(emailConfiguration.getPassword());
+
         return mailSender;
     }
 

--- a/plugins/sla-email/src/test/java/com/thinkbiganalytics/metadata/sla/EmailServiceLevelAgreementActionTest.java
+++ b/plugins/sla-email/src/test/java/com/thinkbiganalytics/metadata/sla/EmailServiceLevelAgreementActionTest.java
@@ -30,11 +30,10 @@ public class EmailServiceLevelAgreementActionTest {
         EmailServiceLevelAgreementAction action = new EmailServiceLevelAgreementAction();
         SlaEmailService service = Mockito.mock(SlaEmailService.class);
         action.setEmailService(service);
-        action.sendToAddresses("desc", "sla name", "a@a.com, b@b.com,c@c.com");
+        action.sendToAddresses("a@a.com, b@b.com,c@c.com", "sla name", "desc");
 
-        Mockito.verify(service).sendMail("a@a.com", "SLA Violated: sla name", "desc");
-        Mockito.verify(service).sendMail("b@b.com", "SLA Violated: sla name", "desc");
-        Mockito.verify(service).sendMail("c@c.com", "SLA Violated: sla name", "desc");
+        Mockito.verify(service).sendMail("a@a.com, b@b.com,c@c.com", "SLA Violated: sla name", "desc");
+
     }
 
     @Test
@@ -42,9 +41,10 @@ public class EmailServiceLevelAgreementActionTest {
         EmailServiceLevelAgreementAction action = new EmailServiceLevelAgreementAction();
         SlaEmailService service = Mockito.mock(SlaEmailService.class);
         action.setEmailService(service);
-        action.sendToAddresses("desc", "sla name", "a@a.com");
+        action.sendToAddresses("a@a.com", "sla name", "desc");
 
         Mockito.verify(service).sendMail("a@a.com", "SLA Violated: sla name", "desc");
+
     }
 
 }

--- a/plugins/sla-email/src/test/java/com/thinkbiganalytics/metadata/sla/TestConfiguration.java
+++ b/plugins/sla-email/src/test/java/com/thinkbiganalytics/metadata/sla/TestConfiguration.java
@@ -63,8 +63,8 @@ public class TestConfiguration {
         emailConfiguration.setPort(587);
         //Note Google accounts will not allow overriding the from address due to security reasons.  Other accounts will.
         emailConfiguration.setFrom("some addresss");
-        emailConfiguration.setSmtpAuth(true);
-        emailConfiguration.setStarttls(true);
+        emailConfiguration.setSmtpAuth("true");
+        emailConfiguration.setStarttls("true");
         emailConfiguration.setPassword("someuser@gmail.com password");
         emailConfiguration.setUsername("someuser@gmail.com email address");
         return emailConfiguration;
@@ -74,8 +74,8 @@ public class TestConfiguration {
     public JavaMailSender javaMailSender(@Qualifier("slaEmailConfiguration") EmailConfiguration emailConfiguration) {
         JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
         Properties mailProperties = new Properties();
-        mailProperties.put("mail.smtp.auth", emailConfiguration.isSmtpAuth());
-        mailProperties.put("mail.smtp.starttls.enable", emailConfiguration.isStarttls());
+        mailProperties.put("mail.smtp.auth", emailConfiguration.getSmtpAuth());
+        mailProperties.put("mail.smtp.starttls.enable", emailConfiguration.getStarttls());
         if (StringUtils.isNotBlank(emailConfiguration.getSmptAuthNtmlDomain())) {
             mailProperties.put("mail.smtp.auth.ntlm.domain", emailConfiguration.getSmptAuthNtmlDomain());
         }


### PR DESCRIPTION
- Refactor Message type and multiple address send
- Set defaults for some properties
- Add more configurable mail properties
- Cleaned a bit the doc

There were some issues with properties not correctly taken into account if the values were booleans and odd discrepancies between outlook and gmail behaviour => added more info in the configuration readme.