### PR TITLE
[KYLO-1230] - Adding kylo-nifi-provenance-repo-v1.2-nar dependency

### DIFF
--- a/install/install-tar/pom.xml
+++ b/install/install-tar/pom.xml
@@ -47,6 +47,12 @@
     </dependency>
     <dependency>
       <groupId>com.thinkbiganalytics.kylo.integrations</groupId>
+      <artifactId>kylo-nifi-provenance-repo-v1.2-nar</artifactId>
+      <version>0.8.4-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.thinkbiganalytics.kylo.integrations</groupId>
       <artifactId>kylo-nifi-spark-v1-nar</artifactId>
       <version>0.8.4-SNAPSHOT</version>
       <type>nar</type>


### PR DESCRIPTION
This is to add `kylo-nifi-provenance-repo-v1.2-nar` to `install-tar` dependency list so that we can build it.

-Binh
