### PR TITLE
KYLO-333 Fix Merge using PK for Cloudera

### DIFF
--- a/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/main/java/com/thinkbiganalytics/ingest/TableMergeSyncSupport.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/main/java/com/thinkbiganalytics/ingest/TableMergeSyncSupport.java
@@ -599,7 +599,7 @@ public class TableMergeSyncSupport implements Serializable {
                "  from " + HiveUtils.quoteIdentifier(sourceSchema, sourceTable) + " a" +
                "  where " +
                "  a.processing_dttm = " + HiveUtils.quoteString(feedPartitionValue) +
-               " union " +
+               " union all" +
                "  select " + selectSQLWithAlias +
                "  from " + HiveUtils.quoteIdentifier(targetSchema, targetTable) + " a left outer join (" + sbSourceQuery + ") b " +
                "  on (" + joinOnClause + ")" +


### PR DESCRIPTION
Tested on Cloudera 5.10 with Hive 1.1.
This was failing for Hive < 1.2, as "UNION" alone as a keyword is not recognized