### PR TITLE
KYLO-1455 Fix for dedupe and merge bug with unit test

### DIFF
--- a/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/main/java/com/thinkbiganalytics/ingest/TableMergeSyncSupport.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/main/java/com/thinkbiganalytics/ingest/TableMergeSyncSupport.java
@@ -543,7 +543,7 @@ public class TableMergeSyncSupport implements Serializable {
 
         return "insert into table " + HiveUtils.quoteIdentifier(targetSchema, targetTable) + " " +
                "select " + selectAggregateSQL + " from (" +
-               " select " + selectSQL +
+               " select distinct " + selectSQL +
                " from " + HiveUtils.quoteIdentifier(sourceSchema, sourceTable) + " where processing_dttm = " + HiveUtils.quoteString(feedPartitionValue) + " " +
                " union all " +
                " select " + selectSQL +


### PR DESCRIPTION
- added 'distinct' to select of source table to deduplicate incoming records before merge
- added unit test to verify fix
