### PR TITLE
Solves the problem of having different guava versions related to the FluentIterable.toList method

### DIFF
--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-core/src/main/java/com/thinkbiganalytics/spark/datavalidator/functions/CleanseAndValidateRow.java
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-core/src/main/java/com/thinkbiganalytics/spark/datavalidator/functions/CleanseAndValidateRow.java
@@ -9,9 +9,9 @@ package com.thinkbiganalytics.spark.datavalidator.functions;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ package com.thinkbiganalytics.spark.datavalidator.functions;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.thinkbiganalytics.policy.BaseFieldPolicy;
 import com.thinkbiganalytics.policy.FieldPolicy;
@@ -331,21 +332,20 @@ public class CleanseAndValidateRow implements Function<Row, CleansedRowResult> {
      */
     @Nonnull
     private List<String> getPolicyMapFeedFieldNames() {
-        return FluentIterable.from(Arrays.asList(policies))
-            .filter(new Predicate<FieldPolicy>() {
-                @Override
-                public boolean apply(@Nullable FieldPolicy input) {
-                    return (input != null && input.getFeedField() != null);
-                }
-            })
-            .transform(new com.google.common.base.Function<FieldPolicy, String>() {
-                @Override
-                public String apply(@Nullable FieldPolicy input) {
-                    assert input != null;
-                    return input.getFeedField().toLowerCase();
-                }
-            })
-            .toList();
+        return ImmutableList.copyOf(FluentIterable.from(Arrays.asList(policies))
+                                        .filter(new Predicate<FieldPolicy>() {
+                                            @Override
+                                            public boolean apply(@Nullable FieldPolicy input) {
+                                                return (input != null && input.getFeedField() != null);
+                                            }
+                                        })
+                                        .transform(new com.google.common.base.Function<FieldPolicy, String>() {
+                                            @Override
+                                            public String apply(@Nullable FieldPolicy input) {
+                                                assert input != null;
+                                                return input.getFeedField().toLowerCase();
+                                            }
+                                        }));
     }
 
     /**


### PR DESCRIPTION
Don't use the renamed toList method of the guava library, but create the ImmutableList directly