### PR TITLE
Adding dynamic class loading capability to Kylo HDFS processors

### DIFF
--- a/integrations/nifi/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hadoop-processors/pom.xml
+++ b/integrations/nifi/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hadoop-processors/pom.xml
@@ -57,6 +57,7 @@
     <dependency>
       <groupId>org.apache.nifi</groupId>
       <artifactId>nifi-api</artifactId>
+      <version>${nifi.version.override}</version>
     </dependency>
 
     <dependency>

--- a/integrations/nifi/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hadoop-processors/src/main/java/com/thinkbiganalytics/nifi/v2/hdfs/AbstractHadoopProcessor.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hadoop-processors/src/main/java/com/thinkbiganalytics/nifi/v2/hdfs/AbstractHadoopProcessor.java
@@ -38,6 +38,7 @@ import org.apache.nifi.components.Validator;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,6 +66,16 @@ public abstract class AbstractHadoopProcessor extends AbstractNiFiProcessor {
         .description("A file or comma separated list of files which contains the Hadoop file system configuration. Without this, Hadoop "
                      + "will search the classpath for a 'core-site.xml' and 'hdfs-site.xml' file or will revert to a default configuration.")
         .required(false).addValidator(createMultipleFilesExistValidator()).build();
+
+    public static final PropertyDescriptor ADDITIONAL_CLASSPATH_RESOURCES = new PropertyDescriptor.Builder()
+        .name("Additional Classpath Resources")
+        .description("A comma-separated list of paths to files and/or directories that will be added to the classpath. When specifying a " +
+                     "directory, all files with in the directory will be added to the classpath, but further sub-directories will not be included.\n" +
+                     "Note: Requires NiFi 1.1+")
+        .required(false)
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .dynamicallyModifiesClasspath(true)
+        .build();
 
     public static final String DIRECTORY_PROP_NAME = "Directory";
 
@@ -158,6 +169,7 @@ public abstract class AbstractHadoopProcessor extends AbstractNiFiProcessor {
         // Create list of properties
         final List<PropertyDescriptor> props = new ArrayList<>();
         props.add(HADOOP_CONFIGURATION_RESOURCES);
+        props.add(ADDITIONAL_CLASSPATH_RESOURCES);
         props.add(kerberosPrincipal);
         props.add(kerberosKeytab);
         props.add(KerberosProperties.KERBEROS_RELOGIN_PERIOD);


### PR DESCRIPTION
Used NiFi's `dynamicallyModifiesClasspath` functionality to add JARs and resources to classpath dynamically. Useful in Hadoop environments that are backed by custom filesystem implementations such as WASB, S3.