### PR TITLE
Kylo 453 0.9.1

### DIFF
--- a/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/main/java/com/thinkbiganalytics/ingest/TableMergeSyncSupport.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/main/java/com/thinkbiganalytics/ingest/TableMergeSyncSupport.java
@@ -145,8 +145,16 @@ public class TableMergeSyncSupport implements Serializable {
         // 3. Drop the sync table. Since it is a managed table it will drop the old data
         dropTable(targetSchema, targetTable);
 
-        // 4. Rename the sync table
+        // 4. Make the table external
+        String markExternal = "ALTER TABLE " + targetSchema + "." + syncTable + " SET TBLPROPERTIES('EXTERNAL'='TRUE')";
+        doExecuteSQL(markExternal);
+
+        // 5. Rename the sync table
         renameTable(targetSchema, syncTable, targetTable);
+
+        // 6. Unmark the table external
+        String unmarkExternal = "ALTER TABLE " + targetSchema + "." + targetTable + " SET TBLPROPERTIES('EXTERNAL'='FALSE')";
+        doExecuteSQL(unmarkExternal);
     }
 
     /**

--- a/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/test/java/com/thinkbiganalytics/ingest/TableMergeSyncSupportTest.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/test/java/com/thinkbiganalytics/ingest/TableMergeSyncSupportTest.java
@@ -146,7 +146,7 @@ public class TableMergeSyncSupportTest {
     /**
      * Tests if HDFS location is correct
      */
-    public void checkSyncLocationHDFS() throws Exception {
+    public void testSyncLocationHDFS() throws Exception {
         // This the check id the schema pre and after a sync is the same
         String describePre = extractTableDirectory(sourceSchema, sourceTable);
 

--- a/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/test/java/com/thinkbiganalytics/ingest/TableMergeSyncSupportTest.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/test/java/com/thinkbiganalytics/ingest/TableMergeSyncSupportTest.java
@@ -123,6 +123,46 @@ public class TableMergeSyncSupportTest {
         doTestSync(targetSchema, targetTable, spec);
     }
 
+    /**
+     * Extract the HDFS location of the table data.
+     *
+     * @param schema the schema or database name
+     * @param table  the table name
+     * @return the HDFS location of the table data
+     */
+    private String extractTableDirectory(String schema, String table) {
+        hiveShell.execute("use " + HiveUtils.quoteIdentifier(schema));
+        List<String> description = hiveShell.executeQuery("show table extended like " + HiveUtils.quoteIdentifier(table));
+        for(String line : description) {
+            if (line.startsWith("location:")) {
+                // Take table directory
+                return line.substring(9, line.lastIndexOf("/"));
+            }
+        }
+        return null;
+    }
+
+    @Test
+    /**
+     * Tests if HDFS location is correct
+     */
+    public void checkSyncLocationHDFS() throws Exception {
+        // This the check id the schema pre and after a sync is the same
+        String describePre = extractTableDirectory(sourceSchema, sourceTable);
+
+        // Test without Partitions
+        mergeSyncSupport.doSync(sourceSchema, sourceTable, targetSchema, targetTableNP, specNP, processingPartition);
+        String describePost = extractTableDirectory(targetSchema, targetTableNP);
+        if((describePre == null) || (describePost == null)) assert(false);
+        assert(describePre.equals(describePost));
+
+        // Test with Partitions
+        mergeSyncSupport.doSync(sourceSchema, sourceTable, targetSchema, targetTable, spec, processingPartition);
+        describePost = extractTableDirectory(targetSchema, targetTable);
+        if((describePre == null) || (describePost == null)) assert(false);
+        assert(describePre.equals(describePost));
+    }
+
     @Test
     /**
      * Tests the sync function


### PR DESCRIPTION
The fix is for the Jira https://kylo-io.atlassian.net/browse/KYLO-453. 
The issue is created due to the fact that on Hive, the rename table command for a managed table changes also the location of the data.
The fix proposed is to make external the target table, rename it and then to make managed. 
The steps are:
1. Create a temporary "sync" table for storing our latest snapshot
2. Populate the temporary "sync" table
3. Drop the sync table. Since it is a managed table it will drop the old data
4. Make the table external
5. Rename the sync table
6. Unmark the table external
The steps 4 and 6 are the added with respect to the original code.
The test testSyncLocationHDFS checks the location correctness of the proposed fix.