### PR TITLE
[KYLO-2572] The 400 error (bad request) is caused by an revision issu…

### DIFF
--- a/integrations/nifi/nifi-rest/nifi-rest-client/nifi-rest-client-api/src/main/java/com/thinkbiganalytics/nifi/rest/client/AbstractNiFiControllerServicesRestClient.java
+++ b/integrations/nifi/nifi-rest/nifi-rest-client/nifi-rest-client-api/src/main/java/com/thinkbiganalytics/nifi/rest/client/AbstractNiFiControllerServicesRestClient.java
@@ -148,6 +148,7 @@ public abstract class AbstractNiFiControllerServicesRestClient implements NiFiCo
                     //error unable to change the state of the references. ... error
                     throw new NifiClientRuntimeException("Unable to stop processor references to this controller service " + controllerService.getName() + " before making the update");
                 }
+                processorRevisions.values().forEach(r -> r.setVersion(r.getVersion()+1L));
             }
 
             //disable any controller service references


### PR DESCRIPTION
[KYLO-2572] The 400 error (bad request) is caused by an revision issue. NiFi uses revision version or clientId to validate client's update request. If it doesn't increase the version at that time, it gets 400 error when it try to reset the processor status to 'running'