### PR TITLE
KYLO-2767 Fixed the endpoint issue for AWS elastic search.  The url f…

### DIFF
--- a/plugins/search-elasticsearch-rest/src/main/java/com/thinkbiganalytics/search/ElasticSearchRestService.java
+++ b/plugins/search-elasticsearch-rest/src/main/java/com/thinkbiganalytics/search/ElasticSearchRestService.java
@@ -67,7 +67,7 @@ public class ElasticSearchRestService implements Search {
     private static final String POST_METHOD = "POST";
     private static final String PUT_METHOD = "PUT";
     private static final String DELETE_METHOD = "DELETE";
-    private static final String SEARCH_ENDPOINT = "_search";
+    private static final String SEARCH_ENDPOINT = "/_search";
     private static final String VERSION_TWO = "2";
     private static final String QUERY = "query";
 


### PR DESCRIPTION
…ormed is not correct POST http://<es_domain_name>:80_search it should be POST http://<es_domain_name>:80/search