### PR TITLE
KYLO-3248 [Refactoring] Performance - Method invokes inefficient Numb…

### DIFF
--- a/commons/commons-spark/commons-spark-repl/src/test/java/com/thinkbiganalytics/spark/repl/SparkScriptEngineTest.java
+++ b/commons/commons-spark/commons-spark-repl/src/test/java/com/thinkbiganalytics/spark/repl/SparkScriptEngineTest.java
@@ -107,7 +107,7 @@ public class SparkScriptEngineTest {
      */
     @Test
     public void test() throws Exception {
-        Assert.assertEquals(3, engine.eval("new Integer(1 + 2)"));
+        Assert.assertEquals(3, engine.eval("Integer.valueOf(1 + 2)"));
     }
 
     /**

--- a/core/job-repository/job-repository-core/src/main/java/com/thinkbiganalytics/jobrepo/query/model/transform/JobStatusTransform.java
+++ b/core/job-repository/job-repository-core/src/main/java/com/thinkbiganalytics/jobrepo/query/model/transform/JobStatusTransform.java
@@ -64,7 +64,7 @@ public class JobStatusTransform {
                 JobStatusCount first = jobStatusCounts.get(0);
                 JobStatusCount min = new JobStatusCountResult(first);
                 min.setDate(firstDate);
-                min.setCount(new Long(0));
+                min.setCount(Long.valueOf(0));
                 jobStatusCounts.add(min);
             }
         }

--- a/core/nifi-provenance/nifi-provenance-model/src/main/java/com/thinkbiganalytics/nifi/provenance/AggregationEventProcessingStats.java
+++ b/core/nifi-provenance/nifi-provenance-model/src/main/java/com/thinkbiganalytics/nifi/provenance/AggregationEventProcessingStats.java
@@ -33,7 +33,7 @@ public class AggregationEventProcessingStats {
 
 
     public static Long addStreamingEvents(int num) {
-        return streamingEventsSentToJms.addAndGet(new Long(num));
+        return streamingEventsSentToJms.addAndGet(Long.valueOf(num));
     }
 
     public static Long getStreamingEventsSent() {
@@ -41,7 +41,7 @@ public class AggregationEventProcessingStats {
     }
 
     public static Long addBatchEvents(int num) {
-        return batchEventsSentToJms.addAndGet(new Long(num));
+        return batchEventsSentToJms.addAndGet(Long.valueOf(num));
     }
 
     public static Long getBatchEventsSent() {

--- a/core/ui-annotation/ui-annotation-core/src/main/java/com/thinkbiganalytics/policy/BasePolicyAnnotationTransformer.java
+++ b/core/ui-annotation/ui-annotation-core/src/main/java/com/thinkbiganalytics/policy/BasePolicyAnnotationTransformer.java
@@ -445,7 +445,7 @@ public abstract class BasePolicyAnnotationTransformer<U extends BaseUiPolicyRule
         } else if (Number.class.equals(type)) {
             return NumberUtils.createNumber(value);
         } else if (Integer.class.equals(type) || Integer.TYPE.equals(type)) {
-            return new Integer(value);
+            return Integer.valueOf(value);
         } else if (Long.class.equals(type) || Long.TYPE.equals(type)) {
             return Long.valueOf(value);
         } else if (Double.class.equals(type) || Double.TYPE.equals(type)) {

--- a/integrations/jira/jira-rest-client/src/main/java/com/thinkbiganalytics/jira/domain/BasicIssue.java
+++ b/integrations/jira/jira-rest-client/src/main/java/com/thinkbiganalytics/jira/domain/BasicIssue.java
@@ -38,7 +38,7 @@ public class BasicIssue {
         try {
             this.self = new URI(getIssue.getSelf());
             this.key = getIssue.getKey();
-            this.id = new Long(getIssue.getId());
+            this.id = Long.valueOf(getIssue.getId());
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/test/java/com/thinkbiganalytics/nifi/v2/metadata/TriggerFeedTest.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-core-bundle/nifi-core-processors/src/test/java/com/thinkbiganalytics/nifi/v2/metadata/TriggerFeedTest.java
@@ -56,7 +56,7 @@ public class TriggerFeedTest {
             Map<String, Object> executionContext = new HashMap<>();
             executionContext.put("param1", "test");
             executionContext.put("export.kylo.param2", "test2");
-            deltaResults.addFeedExecutionContext(feedName, new Long(1), DateTime.now(), DateTime.now(), executionContext);
+            deltaResults.addFeedExecutionContext(feedName, Long.valueOf(1), DateTime.now(), DateTime.now(), executionContext);
 
         });
 

--- a/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/main/java/com/thinkbiganalytics/nifi/provenance/repo/ConfigurationProperties.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/main/java/com/thinkbiganalytics/nifi/provenance/repo/ConfigurationProperties.java
@@ -112,13 +112,13 @@ public class ConfigurationProperties {
 
     private void setValues() {
         this.backupLocation = properties.getProperty("kylo.provenance.cache.location", DEFAULT_BACKUP_LOCATION);
-        this.maxFeedEvents = new Integer(properties.getProperty("kylo.provenance.max.starting.events", DEFAULT_MAX_EVENTS + ""));
-        this.runInterval = new Long(properties.getProperty("kylo.provenance.run.interval.millis", DEFAULT_RUN_INTERVAL_MILLIS + ""));
+        this.maxFeedEvents = Integer.valueOf(properties.getProperty("kylo.provenance.max.starting.events", DEFAULT_MAX_EVENTS + ""));
+        this.runInterval = Long.valueOf(properties.getProperty("kylo.provenance.run.interval.millis", DEFAULT_RUN_INTERVAL_MILLIS + ""));
 
-        this.throttleStartingFeedFlowsThreshold = new Integer(properties.getProperty("kylo.provenance.event.count.throttle.threshold", DEFAULT_THROTTLE_STARTING_FEED_FLOWS_THRESHOLD + ""));
-        this.throttleStartingFeedFlowsTimePeriodMillis = new Integer(properties.getProperty("kylo.provenance.event.throttle.threshold.time.millis", DEFAULT_THROTTLE_STARTING_FEED_FLOWS_TIME_PERIOD_MILLIS + ""));
+        this.throttleStartingFeedFlowsThreshold = Integer.valueOf(properties.getProperty("kylo.provenance.event.count.throttle.threshold", DEFAULT_THROTTLE_STARTING_FEED_FLOWS_THRESHOLD + ""));
+        this.throttleStartingFeedFlowsTimePeriodMillis = Integer.valueOf(properties.getProperty("kylo.provenance.event.throttle.threshold.time.millis", DEFAULT_THROTTLE_STARTING_FEED_FLOWS_TIME_PERIOD_MILLIS + ""));
         orphanChildFlowFileProcessorsString = properties.getProperty("kylo.provenance.orphan.child.flowfile.processors", DEFAULT_ORPHAN_CHILD_FLOW_FILE_PROCESSORS);
-        this.remoteInputPortExpireTimeSeconds = new Integer(properties.getProperty("kylo.provenance.remote.event.expire.time.seconds",DEFAULT_REMOTE_INPUT_PORT_EXPIRE_TIME_SECONDS+""));
+        this.remoteInputPortExpireTimeSeconds = Integer.valueOf(properties.getProperty("kylo.provenance.remote.event.expire.time.seconds",DEFAULT_REMOTE_INPUT_PORT_EXPIRE_TIME_SECONDS+""));
         //only update this on the initial run.  Any changes will be detected and updated with the ConfigurationPropertiesRefresher
         if(lastModified == null) {
             FeedEventStatistics.getInstance().updateEventTypeProcessorTypeSkipChildren(orphanChildFlowFileProcessorsString);

--- a/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/main/java/com/thinkbiganalytics/nifi/provenance/repo/ConfigurationPropertiesRefresher.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/main/java/com/thinkbiganalytics/nifi/provenance/repo/ConfigurationPropertiesRefresher.java
@@ -52,12 +52,12 @@ public class ConfigurationPropertiesRefresher {
             if (changes != null && !changes.isEmpty()) {
                 ConfigurationProperties.PropertyChange runInterval = changes.get(ConfigurationProperties.RUN_INTERVAL_KEY);
                 if (runInterval != null) {
-                    FeedStatisticsManager.getInstance().resetStatisticsInterval(new Long(runInterval.getNewValue()));
+                    FeedStatisticsManager.getInstance().resetStatisticsInterval(Long.valueOf(runInterval.getNewValue()));
                     log.info("Reset {} ", runInterval);
                 }
                 ConfigurationProperties.PropertyChange maxEvents = changes.get(ConfigurationProperties.MAX_FEED_EVENTS_KEY);
                 if (maxEvents != null) {
-                    FeedStatisticsManager.getInstance().resetMaxEvents(new Integer(maxEvents.getNewValue()));
+                    FeedStatisticsManager.getInstance().resetMaxEvents(Integer.valueOf(maxEvents.getNewValue()));
                     log.info("Reset {} ", maxEvents);
                 }
                 ConfigurationProperties.PropertyChange backupLocation = changes.get(ConfigurationProperties.BACKUP_LOCATION_KEY);

--- a/integrations/spark/spark-catalog/spark-catalog-core/src/test/java/com/thinkbiganalytics/kylo/catalog/spark/sources/AbstractJdbcDataSetProviderTest.java
+++ b/integrations/spark/spark-catalog/spark-catalog-core/src/test/java/com/thinkbiganalytics/kylo/catalog/spark/sources/AbstractJdbcDataSetProviderTest.java
@@ -186,7 +186,7 @@ public class AbstractJdbcDataSetProviderTest {
         final JdbcHighWaterMark highWaterMark = provider.createHighWaterMark("mockWaterMark", client);
 
         Assert.assertEquals("mockWaterMark", highWaterMark.getName());
-        Assert.assertEquals(new Long(1525014303000L), highWaterMark.getValue());
+        Assert.assertEquals(Long.valueOf(1525014303000L), highWaterMark.getValue());
         Mockito.reset(client);
 
         // Test adding a value
@@ -282,11 +282,11 @@ public class AbstractJdbcDataSetProviderTest {
 
         // Test non-null overlap
         options.setOption("overlap", "60");
-        Assert.assertEquals(new Long(60000), provider.getOverlap(options));
+        Assert.assertEquals(Long.valueOf(60000), provider.getOverlap(options));
 
         // Test negative overlap
         options.setOption("overlap", "-5");
-        Assert.assertEquals(new Long(5000), provider.getOverlap(options));
+        Assert.assertEquals(Long.valueOf(5000), provider.getOverlap(options));
     }
 
     /**

--- a/integrations/spark/spark-catalog/spark-catalog-core/src/test/java/com/thinkbiganalytics/kylo/catalog/spark/sources/jdbc/JdbcHighWaterMarkAccumulableParamTest.java
+++ b/integrations/spark/spark-catalog/spark-catalog-core/src/test/java/com/thinkbiganalytics/kylo/catalog/spark/sources/jdbc/JdbcHighWaterMarkAccumulableParamTest.java
@@ -36,10 +36,10 @@ public class JdbcHighWaterMarkAccumulableParamTest {
         final JdbcHighWaterMark highWaterMark = new JdbcHighWaterMark();
         final JdbcHighWaterMarkAccumulableParam param = new JdbcHighWaterMarkAccumulableParam();
         param.addAccumulator(highWaterMark, 1L);
-        Assert.assertEquals(new Long(1L), highWaterMark.getValue());
+        Assert.assertEquals(Long.valueOf(1L), highWaterMark.getValue());
 
         param.addAccumulator(highWaterMark, 2L);
-        Assert.assertEquals(new Long(2L), highWaterMark.getValue());
+        Assert.assertEquals(Long.valueOf(2L), highWaterMark.getValue());
     }
 
     /**
@@ -54,7 +54,7 @@ public class JdbcHighWaterMarkAccumulableParamTest {
         right.accumulate(2L);
 
         final JdbcHighWaterMark result = new JdbcHighWaterMarkAccumulableParam().addInPlace(left, right);
-        Assert.assertEquals(new Long(2L), result.getValue());
+        Assert.assertEquals(Long.valueOf(2L), result.getValue());
         Assert.assertEquals(left, result);
     }
 

--- a/integrations/spark/spark-catalog/spark-catalog-core/src/test/java/com/thinkbiganalytics/kylo/catalog/spark/sources/jdbc/JdbcHighWaterMarkTest.java
+++ b/integrations/spark/spark-catalog/spark-catalog-core/src/test/java/com/thinkbiganalytics/kylo/catalog/spark/sources/jdbc/JdbcHighWaterMarkTest.java
@@ -47,19 +47,19 @@ public class JdbcHighWaterMarkTest {
 
         // Test first non-null value
         highWaterMark.accumulate(2L);
-        Assert.assertEquals(new Long(2L), highWaterMark.getValue());
+        Assert.assertEquals(Long.valueOf(2L), highWaterMark.getValue());
 
         // Test lower value
         highWaterMark.accumulate(1L);
-        Assert.assertEquals(new Long(2L), highWaterMark.getValue());
+        Assert.assertEquals(Long.valueOf(2L), highWaterMark.getValue());
 
         // Test null value
         highWaterMark.accumulate(null);
-        Assert.assertEquals(new Long(2L), highWaterMark.getValue());
+        Assert.assertEquals(Long.valueOf(2L), highWaterMark.getValue());
 
         // Test higher value
         highWaterMark.accumulate(3L);
-        Assert.assertEquals(new Long(3L), highWaterMark.getValue());
+        Assert.assertEquals(Long.valueOf(3L), highWaterMark.getValue());
     }
 
     /**

--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-core/src/main/java/com/thinkbiganalytics/spark/validation/HCatDataType.java
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-core/src/main/java/com/thinkbiganalytics/spark/validation/HCatDataType.java
@@ -249,7 +249,7 @@ public class HCatDataType implements Cloneable, Serializable {
             if (StringUtils.isEmpty(val) || convertibleType == String.class) {
                 return (unchecked || isstring ? (T) val : null);
             } else if (convertibleType == Integer.class) {
-                return (T) new Integer(val);
+                return (T) Integer.valueOf(val);
             } else if (convertibleType == Double.class) {
                 return (T) new Double(val);
             } else if (convertibleType == Float.class) {

--- a/metadata/metadata-core/src/test/java/com/thinkbiganalytics/metadata/event/reactor/ReactorMetadataEventServiceTest.java
+++ b/metadata/metadata-core/src/test/java/com/thinkbiganalytics/metadata/event/reactor/ReactorMetadataEventServiceTest.java
@@ -97,7 +97,7 @@ public class ReactorMetadataEventServiceTest {
         }
 
         service.addListener(new TestEventListener());
-        service.notify(new TestEvent(new Integer(1)));
+        service.notify(new TestEvent(Integer.valueOf(1)));
 
         Number result = future.get();
 

--- a/metadata/metadata-modeshape/src/main/java/com/thinkbiganalytics/metadata/modeshape/op/JobRepoFeedOperationsProvider.java
+++ b/metadata/metadata-modeshape/src/main/java/com/thinkbiganalytics/metadata/modeshape/op/JobRepoFeedOperationsProvider.java
@@ -148,7 +148,7 @@ public class JobRepoFeedOperationsProvider implements FeedOperationsProvider {
     @Override
     public FeedOperation getOperation(ID id) {
         OpId opId = (OpId) id;
-        BatchJobExecution jobExecution = jobExecutionProvider.findByJobExecutionId(new Long(opId.toString()),false);
+        BatchJobExecution jobExecution = jobExecutionProvider.findByJobExecutionId(Long.valueOf(opId.toString()),false);
         if (jobExecution != null) {
             return createOperation(jobExecution);
         } else {

--- a/plugins/service-monitor-cloudera/service-monitor-cloudera-service/src/main/java/com/thinkbiganalytics/servicemonitor/rest/client/cdh/ClouderaClient.java
+++ b/plugins/service-monitor-cloudera/service-monitor-cloudera-service/src/main/java/com/thinkbiganalytics/servicemonitor/rest/client/cdh/ClouderaClient.java
@@ -73,7 +73,7 @@ public class ClouderaClient {
         if (StringUtils.isBlank(portString)) {
             portString = "7180";
         }
-        Integer port = new Integer(portString);
+        Integer port = Integer.valueOf(portString);
         String username = clientConfig.getUsername();
         String password = clientConfig.getPassword();
 

--- a/plugins/service-monitor-cloudera/service-monitor-cloudera-service/src/main/java/com/thinkbiganalytics/servicemonitor/rest/client/cdh/ClouderaRootResourceManager.java
+++ b/plugins/service-monitor-cloudera/service-monitor-cloudera-service/src/main/java/com/thinkbiganalytics/servicemonitor/rest/client/cdh/ClouderaRootResourceManager.java
@@ -43,7 +43,7 @@ class ClouderaRootResourceManager {
     static ClouderaRootResource getRootResource(ApiRootResource apiRootResource) {
 
         String version = apiRootResource.getCurrentVersion();
-        Integer numericVersion = new Integer(StringUtils.substringAfter(version, "v"));
+        Integer numericVersion = Integer.valueOf(StringUtils.substringAfter(version, "v"));
         RootResourceV1 rootResource = null;
         Integer maxVersion = 10;
         if (numericVersion > maxVersion) {

--- a/services/feed-manager-service/feed-manager-controller/src/main/java/com/thinkbiganalytics/feedmgr/service/template/RegisteredTemplateService.java
+++ b/services/feed-manager-service/feed-manager-controller/src/main/java/com/thinkbiganalytics/feedmgr/service/template/RegisteredTemplateService.java
@@ -777,9 +777,9 @@ public class RegisteredTemplateService {
                     if (!"NEW".equals(id) && (exclude == null || (exclude != null && !exclude.contains(id)))) {
                         FeedManagerTemplate template = templateProvider.findById(templateProvider.resolveId(id));
                         if (template != null) {
-                            if (template.getOrder() == null || !template.getOrder().equals(new Long(i))) {
+                            if (template.getOrder() == null || !template.getOrder().equals(Long.valueOf(i))) {
                                 //save the new order
-                                template.setOrder(new Long(i));
+                                template.setOrder(Long.valueOf(i));
                                 templateProvider.update(template);
                             }
                         }

--- a/services/operational-metadata-service/operational-metadata-integration-service/src/main/java/com/thinkbiganalytics/metadata/cache/FeedHealthSummaryCache.java
+++ b/services/operational-metadata-service/operational-metadata-integration-service/src/main/java/com/thinkbiganalytics/metadata/cache/FeedHealthSummaryCache.java
@@ -257,7 +257,7 @@ public class FeedHealthSummaryCache implements TimeBasedCache<FeedSummary> {
 
         //Transform it to FeedSummary objects
         FeedStatus feedStatus = FeedModelTransform.feedStatus(feedSummaryHealth);
-        Long total = new Long(list.size());
+        Long total = Long.valueOf(list.size());
         searchResult.setData(feedStatus.getFeedSummary());
         searchResult.setRecordsTotal(total);
         searchResult.setRecordsFiltered(total);

--- a/services/operational-metadata-service/operational-metadata-integration-service/src/test/java/com/thinkbiganalytics/alerts/spi/defaults/DefaultAlertManagerTest.java
+++ b/services/operational-metadata-service/operational-metadata-integration-service/src/test/java/com/thinkbiganalytics/alerts/spi/defaults/DefaultAlertManagerTest.java
@@ -199,7 +199,7 @@ public class DefaultAlertManagerTest extends AbstractTestNGSpringContextTests {
             .extracting("state", "description", "content")
             .contains(Assertions.tuple(State.UNHANDLED, null, null), Assertions.tuple(State.IN_PROGRESS, TRUNK_DESCR, null));
 
-        alert = resp.handle("Change handled", new Integer(42));
+        alert = resp.handle("Change handled", Integer.valueOf(42));
 
         Assertions.assertThat(alert.getEvents())
             .hasSize(3)

--- a/services/repository-service/src/main/java/com/thinkbiganalytics/repository/filesystem/FilesystemRepositoryService.java
+++ b/services/repository-service/src/main/java/com/thinkbiganalytics/repository/filesystem/FilesystemRepositoryService.java
@@ -328,7 +328,7 @@ public class FilesystemRepositoryService implements RepositoryService {
             .limit(filter.getLimit() > 0 ? filter.getLimit() : Integer.MAX_VALUE)
             .collect(Collectors.toList());
 
-        Long total = new Long(templates.size());
+        Long total = Long.valueOf(templates.size());
         searchResult.setData(data);
         searchResult.setRecordsTotal(total);
         searchResult.setRecordsFiltered(total);

--- a/services/spark-shell-service/spark-shell-rest-model/src/main/java/com/thinkbiganalytics/spark/rest/model/FileMetadataResponse.java
+++ b/services/spark-shell-service/spark-shell-rest-model/src/main/java/com/thinkbiganalytics/spark/rest/model/FileMetadataResponse.java
@@ -147,7 +147,7 @@ public class FileMetadataResponse {
         public Integer getHeaderCount() {
             String headerCount = getProperties().get("headerCount");
             if (headerCount != null) {
-                return new Integer(headerCount);
+                return Integer.valueOf(headerCount);
             } else {
                 return 0;
             }


### PR DESCRIPTION
Using new Integer(int) is guaranteed to always result in a new object whereas Integer.valueOf(int) allows caching of values to be done by the compiler, class library, or JVM. Using of cached values avoids object allocation and the code will be faster.

Values between -128 and 127 are guaranteed to have corresponding cached instances and using valueOf is approximately 3.5 times faster than using constructor. For values outside the constant range the performance of both styles is the same.

Unless the class must be compatible with JVMs predating Java 1.5, use either autoboxing or the valueOf() method when creating instances of Long, Integer, Short, Character, and Byte.