### PR TITLE
KYLO-3276 Fix memory leak

### DIFF
--- a/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/main/java/com/thinkbiganalytics/nifi/provenance/repo/FeedEventStatistics.java
+++ b/integrations/nifi/nifi-nar-bundles/nifi-provenance-repo-bundle/nifi-provenance-repo/src/main/java/com/thinkbiganalytics/nifi/provenance/repo/FeedEventStatistics.java
@@ -847,8 +847,6 @@ public class FeedEventStatistics implements Serializable {
 
             if (canClear) {
                 clearEventAndTrackingData(eventId, eventFlowFileId);
-                eventDuration.remove(eventId);
-                eventStartTime.remove(eventId);
             }
             else {
                 //we need to reprocess this
@@ -859,6 +857,8 @@ public class FeedEventStatistics implements Serializable {
 
 
         }
+        eventDuration.remove(eventId);
+        eventStartTime.remove(eventId);
     }
 
     private void clearEventAndTrackingData(Long eventId, String eventFlowFileId) {


### PR DESCRIPTION
Remove EventId from eventDuration &  eventStartTime when cleanup any ProvenanceEvent